### PR TITLE
Change "Copyright" to "License" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Lightweight android notes app with Material You.
 
 ---
 
-## ⚠️ Copyright
+## ⚠️ License
 
     Copyright (c)2024 kin69
     


### PR DESCRIPTION
A free software/open source license isn't "copyright", you're basically giving that up by using such a license. I think "License" fits better there.