### PR TITLE
Markdown fix

### DIFF
--- a/app/src/main/java/com/kin/easynotes/presentation/components/markdown/LineProccesor.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/components/markdown/LineProccesor.kt
@@ -31,11 +31,11 @@ class CodeBlockProcessor : MarkdownLineProcessor {
 }
 
 class CheckboxProcessor : MarkdownLineProcessor {
-    override fun canProcessLine(line: String): Boolean = line.trim().matches(Regex("\\[[ xX]]( .*)?"))
+    override fun canProcessLine(line: String): Boolean = line.trim().matches(Regex("^\\[[ xX]]( .*)?"))
 
     override fun processLine(line: String, builder: MarkdownBuilder) {
-        val checked = line.contains(Regex("\\[[Xx]]"))
-        val text = line.replace(Regex("\\[[ xX]] ?"), "").trim()
+        val checked = line.contains(Regex("^\\[[Xx]]"))
+        val text = line.replace(Regex("^\\[[ xX]] ?"), "").trim()
         builder.add(CheckboxItem(text, checked, builder.lineIndex))
     }
 }

--- a/app/src/main/java/com/kin/easynotes/presentation/components/markdown/LineProccesor.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/components/markdown/LineProccesor.kt
@@ -31,7 +31,7 @@ class CodeBlockProcessor : MarkdownLineProcessor {
 }
 
 class CheckboxProcessor : MarkdownLineProcessor {
-    override fun canProcessLine(line: String): Boolean = line.trim().matches(Regex("^\\[[ xX]]( .*)?"))
+    override fun canProcessLine(line: String): Boolean = line.matches(Regex("^\\[[ xX]]( .*)?"))
 
     override fun processLine(line: String, builder: MarkdownBuilder) {
         val checked = line.contains(Regex("^\\[[Xx]]"))


### PR DESCRIPTION
These changes should address issues mentioned in https://github.com/Kin69/EasyNotes/issues/45

1. string replacement by range not search (caused multiple line update)
2. add selected markdown at new line, not at the end of the file
3. selection (input cursor location) is conditionally calculated (based on point 2)
4. regex for checkbox includes start of the line w/o trim - for consistency with other markdown types