### PR TITLE
Implement heading levels

### DIFF
--- a/app/src/main/java/com/kin/easynotes/presentation/components/markdown/Elements.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/components/markdown/Elements.kt
@@ -30,10 +30,10 @@ data class ListItem(val text: String) : MarkdownElement {
     }
 }
 
-data class CodeBlock(val code: String, val iSEnded: Boolean = false, val firstLine : String) : MarkdownElement {
+data class CodeBlock(val code: String, val isEnded: Boolean = false, val firstLine : String) : MarkdownElement {
     override fun render(builder: StringBuilder) {
         builder.append("```")
-        iSEnded.let {
+        isEnded.let {
             builder.append(it)
         }
         builder.append("\n$code\n```\n")

--- a/app/src/main/java/com/kin/easynotes/presentation/components/markdown/MarkdownText.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/components/markdown/MarkdownText.kt
@@ -122,10 +122,14 @@ fun MarkdownText(
                 is Heading -> {
                     Text(
                         text = element.text,
-                        fontSize = 24.sp,
+                        fontSize = when(element.level) {
+                            in 1..6 -> (28 - (2 * element.level)).sp
+                            else -> fontSize
+                        },
                         overflow = overflow,
                         fontWeight = weight,
                         maxLines = maxLines,
+                        modifier = Modifier.padding(vertical = 5.dp),
                     )
                 }
                 is CheckboxItem -> {
@@ -162,7 +166,7 @@ fun MarkdownText(
                     MarkdownQuote(content = element.text, fontSize = fontSize)
                 }
                 is CodeBlock -> {
-                    if (element.iSEnded) {
+                    if (element.isEnded) {
                         MarkdownCodeBlock(color = MaterialTheme.colorScheme.surfaceContainerLow) {
                             Text(
                                 text = element.code.dropLast(1),
@@ -171,7 +175,7 @@ fun MarkdownText(
                                 overflow = overflow,
                                 maxLines = maxLines,
                                 fontFamily = FontFamily.Monospace,
-                                modifier = Modifier.padding(6.dp)
+                                modifier = Modifier.padding(6.dp),
                             )
                         }
                     } else {
@@ -181,7 +185,6 @@ fun MarkdownText(
                             fontSize = fontSize,
                             overflow = overflow,
                             maxLines = maxLines,
-
                         )
                     }
                 }
@@ -192,7 +195,6 @@ fun MarkdownText(
                         fontSize = fontSize,
                         overflow = overflow,
                         maxLines = maxLines,
-
                     )
                 }
             }


### PR DESCRIPTION
<details>
<summary>Screenshot</summary>

![by70MQgFaNo](https://github.com/Kin69/EasyNotes/assets/135337715/718774d3-4b73-40c3-80f2-32962a02e8fc)

</details> 

Also fixed typo in `Elements.kt` (`iSEnded` -> `isEnded`)