### PR TITLE
Fixed multiple note select

### DIFF
--- a/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteGrid.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteGrid.kt
@@ -95,7 +95,9 @@ private fun handleShortClick(
 }
 
 private fun handleLongClick(selectedNotes: MutableList<Int>, note: Note) {
-    selectedNotes.add(note.id)
+    if (!selectedNotes.contains(note.id)) {
+        selectedNotes.add(note.id)
+    }
 }
 
 private fun handleDeleteAnimation(


### PR DESCRIPTION
This PR fixes bug:
- When you long press the same note, it could be selected several times
- Removing it caused a crash

<details><summary>Screenshot</summary>

![image](https://github.com/Kin69/EasyNotes/assets/135337715/38baee64-94ec-4cb0-a7b5-1e0a121ccf4a)

</details> 