### PR TITLE
Rewriting the logic of theme change

### DIFF
--- a/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
@@ -154,11 +154,14 @@ fun BottomModal(viewModel: EditViewModel) {
     ) {
         val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
 
-        Column(modifier = Modifier.padding(16.dp,0.dp,16.dp,16.dp)) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp,0.dp,16.dp,16.dp)
+                .clip(RoundedCornerShape(32.dp))
+        ) {
             SettingsBox(
                 title = stringResource(R.string.created_time),
                 icon = Icons.Rounded.Numbers,
-                shape = RoundedCornerShape(16.dp,16.dp,0.dp,0.dp),
                 actionType = ActionType.TEXT,
                 customText = sdf.format(viewModel.noteCreatedTime.value).toString()
             )
@@ -171,7 +174,6 @@ fun BottomModal(viewModel: EditViewModel) {
             SettingsBox(
                 title = stringResource(R.string.characters),
                 icon = Icons.Rounded.Numbers,
-                shape = RoundedCornerShape(0.dp,0.dp,16.dp,16.dp),
                 actionType = ActionType.TEXT,
                 customText = viewModel.noteDescription.value.text.length.toString()
             )

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/edit/components/CustomTextField.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/edit/components/CustomTextField.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 
@@ -27,7 +28,9 @@ fun CustomTextField(
         value = value,
         onValueChange = onValueChange,
         interactionSource = interactionSource,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(shape),
         colors = TextFieldDefaults.colors(
             focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
@@ -166,15 +166,48 @@ fun ColorStylesScreen(navController: NavController, settingsViewModel: SettingsV
             LazyColumn (
                 modifier = Modifier.clip(RoundedCornerShape(32.dp))
             ) {
-                item { SettingsBox(title = stringResource(id = R.string.system_theme), icon = Icons.Rounded.HdrAuto, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.automaticTheme,switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = it))}) }
+                item {
+                    SettingsBox(
+                        title = stringResource(id = R.string.system_theme),
+                        icon = Icons.Rounded.HdrAuto,
+                        actionType = ActionType.SWITCH,
+                        variable = settingsViewModel.settings.value.automaticTheme,
+                        switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = it))}
+                    )
+                }
 
                 if (!settingsViewModel.settings.value.automaticTheme) {
-                    item { SettingsBox(title = stringResource(id = R.string.dark_theme), icon = Icons.Rounded.DarkMode, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.darkTheme, switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, darkTheme = it))}) }
-                    item { SettingsBox(title = stringResource(id = R.string.dynamic_colors), icon = Icons.Rounded.Colorize, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.dynamicTheme, switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, dynamicTheme = it))}) }
+                    item {
+                        SettingsBox(
+                            title = stringResource(id = R.string.dark_theme),
+                            icon = Icons.Rounded.DarkMode,
+                            actionType = ActionType.SWITCH,
+                            variable = settingsViewModel.settings.value.darkTheme,
+                            switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, darkTheme = it))}
+                        )
+                    }
+
+                    item {
+                        SettingsBox(
+                            title = stringResource(id = R.string.dynamic_colors),
+                            icon = Icons.Rounded.Colorize,
+                            actionType = ActionType.SWITCH,
+                            variable = settingsViewModel.settings.value.dynamicTheme,
+                            switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, dynamicTheme = it))}
+                        )
+                    }
                 }
 
                 if (settingsViewModel.settings.value.darkTheme) {
-                    item { SettingsBox(title = stringResource(id = R.string.amoled_colors), icon = Icons.Rounded.Palette, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.amoledTheme, switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(amoledTheme = it))}) }
+                    item {
+                        SettingsBox(
+                            title = stringResource(id = R.string.amoled_colors),
+                            icon = Icons.Rounded.Palette,
+                            actionType = ActionType.SWITCH,
+                            variable = settingsViewModel.settings.value.amoledTheme,
+                            switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(amoledTheme = it))}
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -162,11 +163,19 @@ fun ColorStylesScreen(navController: NavController, settingsViewModel: SettingsV
             title = stringResource(id = R.string.color_styles),
             onBackNavClicked = { navController.popBackStack() }
         ) {
-            LazyColumn {
-                item { SettingsBox(title = stringResource(id = R.string.system_theme), icon = Icons.Rounded.HdrAuto, actionType = ActionType.SWITCH, shape = RoundedCornerShape(32.dp, 32.dp, 6.dp, 6.dp), variable = settingsViewModel.settings.value.automaticTheme,switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = it))}) }
-                item { SettingsBox(title = stringResource(id = R.string.dark_theme), icon = Icons.Rounded.Palette, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.darkTheme,switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, darkTheme = it))}) }
-                item { SettingsBox(title = stringResource(id = R.string.dynamic_colors), icon = Icons.Rounded.Colorize, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.dynamicTheme,switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, dynamicTheme = it))}) }
-                item { SettingsBox(title = stringResource(id = R.string.amoled_colors), icon = Icons.Rounded.DarkMode, actionType = ActionType.SWITCH,shape = RoundedCornerShape(6.dp, 6.dp, 32.dp, 32.dp) ,variable = settingsViewModel.settings.value.amoledTheme,switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, amoledTheme = it))}) }
+            LazyColumn (
+                modifier = Modifier.clip(RoundedCornerShape(32.dp))
+            ) {
+                item { SettingsBox(title = stringResource(id = R.string.system_theme), icon = Icons.Rounded.HdrAuto, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.automaticTheme,switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = it))}) }
+
+                if (!settingsViewModel.settings.value.automaticTheme) {
+                    item { SettingsBox(title = stringResource(id = R.string.dark_theme), icon = Icons.Rounded.DarkMode, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.darkTheme, switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, darkTheme = it))}) }
+                    item { SettingsBox(title = stringResource(id = R.string.dynamic_colors), icon = Icons.Rounded.Colorize, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.dynamicTheme, switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(automaticTheme = false, dynamicTheme = it))}) }
+                }
+
+                if (settingsViewModel.settings.value.darkTheme) {
+                    item { SettingsBox(title = stringResource(id = R.string.amoled_colors), icon = Icons.Rounded.Palette, actionType = ActionType.SWITCH, variable = settingsViewModel.settings.value.amoledTheme, switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(amoledTheme = it))}) }
+                }
             }
         }
     }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/widgets/settingsBox.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/widgets/settingsBox.kt
@@ -29,7 +29,6 @@ fun SettingsBox(
     icon: ImageVector,
     actionType: ActionType,
     variable: Boolean? = null,
-    shape: RoundedCornerShape = RoundedCornerShape(6.dp),
     switchEnabled: (Boolean) -> Unit = {},
     linkClicked: () -> Unit = {},
     customText: String = ""
@@ -37,7 +36,7 @@ fun SettingsBox(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
-            .clip(shape)
+            .clip(RoundedCornerShape(6.dp))
             .clickable { handleAction(actionType, variable, switchEnabled, linkClicked) }
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .padding(horizontal = 20.dp, vertical = 4.dp)

--- a/app/src/main/java/com/kin/easynotes/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/theme/Theme.kt
@@ -20,11 +20,25 @@ import androidx.core.view.WindowCompat
 import com.kin.easynotes.presentation.screens.settings.model.SettingsViewModel
 
 private fun getColorScheme(context: Context, isDarkTheme: Boolean, isDynamicTheme: Boolean, isAmoledTheme: Boolean): ColorScheme {
-    val colorScheme = if (isDynamicTheme && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        if (isDarkTheme || isAmoledTheme) dynamicDarkColorScheme(context).copy() else dynamicLightColorScheme(context)
-    } else if (isDarkTheme || isAmoledTheme) darkScheme else lightScheme
+    if (isDynamicTheme && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (isDarkTheme) {
+            if (isAmoledTheme) {
+                return dynamicDarkColorScheme(context).copy(surfaceContainerLow = Color.Black, surface = Color.Black)
+            }
 
-    return if (isAmoledTheme) colorScheme.copy(surfaceContainerLow = Color.Black, surface = Color.Black) else colorScheme
+            return dynamicDarkColorScheme(context)
+        } else {
+            return dynamicLightColorScheme(context)
+        }
+    } else if (isDarkTheme) {
+         if (isAmoledTheme) {
+             return darkScheme.copy(surfaceContainerLow = Color.Black, surface = Color.Black)
+         }
+
+        return darkScheme
+    } else {
+        return lightScheme
+    }
 }
 
 @Composable
@@ -40,7 +54,7 @@ fun LeafNotesTheme(
     val context = LocalContext.current
     val activity = LocalView.current.context as Activity
     WindowCompat.getInsetsController(activity.window, activity.window.decorView).apply {
-        isAppearanceLightStatusBars = !(settingsModel.settings.value.darkTheme || settingsModel.settings.value.amoledTheme)
+        isAppearanceLightStatusBars = !settingsModel.settings.value.darkTheme
     }
 
     MaterialTheme(


### PR DESCRIPTION
- With an automatic theme, it is possible to enable the AMOLED theme (if the system has a dark theme enabled).
- When the theme is set to automatic, the "Dark Theme" and "Dynamic Colors" options are hidden.
- When the theme is light, the "Amoled Colors" option is hidden
- Setting box and information box rounding has also been changed.