### PR TITLE
Edit screen improvements 

### DIFF
--- a/app/src/main/java/com/kin/easynotes/presentation/components/markdown/MarkdownText.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/components/markdown/MarkdownText.kt
@@ -118,7 +118,7 @@ fun MarkdownText(
                         overflow = overflow,
                         fontWeight = weight,
                         maxLines = maxLines,
-                        modifier = Modifier.padding(vertical = 5.dp),
+                        modifier = Modifier.padding(vertical = 10.dp)
                     )
                 }
                 is CheckboxItem -> {

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Edit
@@ -156,7 +157,7 @@ fun BottomModal(viewModel: EditViewModel) {
 
         Column(
             modifier = Modifier
-                .padding(16.dp,0.dp,16.dp,16.dp)
+                .padding(16.dp, 0.dp, 16.dp, 16.dp)
                 .clip(RoundedCornerShape(32.dp))
         ) {
             SettingsBox(
@@ -226,12 +227,12 @@ fun PreviewScreen(viewModel: EditViewModel, onClick: () -> Unit) {
     Column(
         modifier = Modifier
             .padding(horizontal = 16.dp, vertical = 16.dp)
-            .clip(RoundedCornerShape(32.dp))
+            .clip(RoundedCornerShape(32.dp)),
     ) {
         if (viewModel.noteName.value.text.isNotBlank()) {
             MarkdownBox(
-                modifier = Modifier.clickable { onClick() },
                 shape = RoundedCornerShape(6.dp),
+                isCopyable = true,
                 content = {
                     MarkdownText(
                         markdown = viewModel.noteName.value.text,
@@ -245,8 +246,8 @@ fun PreviewScreen(viewModel: EditViewModel, onClick: () -> Unit) {
         MarkdownBox(
             shape = RoundedCornerShape(6.dp),
             modifier = Modifier
-                .clickable { onClick() }
                 .fillMaxHeight(),
+            isCopyable = true,
             content = {
                 MarkdownText(
                     markdown = viewModel.noteDescription.value.text,
@@ -263,6 +264,7 @@ fun MarkdownBox(
     modifier: Modifier = Modifier,
     shape: RoundedCornerShape = RoundedCornerShape(0.dp),
     content: @Composable () -> Unit,
+    isCopyable: Boolean = false
 ) {
     Box(
         modifier = modifier
@@ -270,7 +272,7 @@ fun MarkdownBox(
             .background(color = MaterialTheme.colorScheme.surfaceContainerHigh)
             .heightIn(max = 128.dp, min = 42.dp),
     ) {
-        content()
+        if (isCopyable) SelectionContainer { content() } else content()
     }
     Spacer(modifier = Modifier.height(3.dp))
 }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
@@ -188,9 +188,10 @@ fun EditScreen(viewModel: EditViewModel) {
         modifier = Modifier
             .fillMaxSize()
             .padding(top = 16.dp, start = 16.dp, end = 16.dp)
+            .clip(RoundedCornerShape(32.dp))
     ) {
         MarkdownBox(
-            shape = RoundedCornerShape(32.dp,32.dp,6.dp,6.dp),
+            shape = RoundedCornerShape(6.dp),
             content = {
                 CustomTextField(
                     value = viewModel.noteName.value,
@@ -201,7 +202,7 @@ fun EditScreen(viewModel: EditViewModel) {
             }
         )
         MarkdownBox(
-            shape = RoundedCornerShape(6.dp,6.dp,32.dp,32.dp),
+            shape = RoundedCornerShape(6.dp),
             modifier = Modifier
                 .onFocusChanged { isInFocus = it.isFocused }
                 .fillMaxHeight(if (isInFocus) 0.92f else 1f)
@@ -222,20 +223,27 @@ fun EditScreen(viewModel: EditViewModel) {
 @Composable
 fun PreviewScreen(viewModel: EditViewModel, onClick: () -> Unit) {
     if (viewModel.isNoteInfoVisible.value) BottomModal(viewModel)
-    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+            .clip(RoundedCornerShape(32.dp))
+    ) {
+        if (viewModel.noteName.value.text.isNotBlank()) {
+            MarkdownBox(
+                modifier = Modifier.clickable { onClick() },
+                shape = RoundedCornerShape(6.dp),
+                content = {
+                    MarkdownText(
+                        markdown = viewModel.noteName.value.text,
+                        modifier = Modifier.padding(16.dp),
+                        onContentChange = { viewModel.updateNoteName(TextFieldValue(text = it)) }
+                    )
+                }
+            )
+        }
+
         MarkdownBox(
-            modifier = Modifier.clickable { onClick() },
-            shape = RoundedCornerShape(32.dp,32.dp,6.dp,6.dp),
-            content = {
-                MarkdownText(
-                    markdown = viewModel.noteName.value.text,
-                    modifier = Modifier.padding(16.dp),
-                    onContentChange = { viewModel.updateNoteName(TextFieldValue(text = it)) }
-                )
-            }
-        )
-        MarkdownBox(
-            shape = RoundedCornerShape(6.dp,6.dp,32.dp,32.dp),
+            shape = RoundedCornerShape(6.dp),
             modifier = Modifier
                 .clickable { onClick() }
                 .fillMaxHeight(),
@@ -259,7 +267,7 @@ fun MarkdownBox(
     Box(
         modifier = modifier
             .clip(shape)
-            .background(color = MaterialTheme.colorScheme.surfaceContainerHigh,)
+            .background(color = MaterialTheme.colorScheme.surfaceContainerHigh)
             .heightIn(max = 128.dp, min = 42.dp),
     ) {
         content()


### PR DESCRIPTION
This PR brings several improvements to the edit screen:
- [Hide note name when it's empty](https://github.com/Kin69/EasyNotes/commit/2c8302435b9a2432947d7fe3fd700980399e32fe)
- [Make copyable note name and text in preview mode](https://github.com/Kin69/EasyNotes/commit/13dbf576c49a4af28ce5252075377b9a183dc13f)