### PR TITLE
Add 'debug' item to buildTypes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,17 @@ android {
             )
             signingConfig = signingConfigs.getByName("debug")
         }
+
+        debug {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+            signingConfig = signingConfigs.getByName("debug")
+            isDebuggable = true
+            applicationIdSuffix = ".debug"
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
When building from source, and having installed the official app through f-droid at the same time, you will encounter an error.

This is due to only a single applicationID available during build.

I have added an additional build type: 'debug' to the build.gradle.kts file, with the applicationIdSuffix set to ".debug"
I also set 'isDebuggable' to true while I was in there.

Let me know if there is a better way of accomplishing this goal, or a better way of sending a pull request as I am new to application dev.

Thank you.