### PR TITLE
Add screen protection setting

### DIFF
--- a/app/src/main/java/com/kin/easynotes/domain/model/Settings.kt
+++ b/app/src/main/java/com/kin/easynotes/domain/model/Settings.kt
@@ -9,6 +9,7 @@ data class Settings(
     var minimalisticMode: Boolean = false,
     var extremeAmoledMode: Boolean = false,
     var isMarkdownEnabled: Boolean = true,
+    var screenProtection: Boolean = false,
 
     var cornerRadius: Int = 32,
 )

--- a/app/src/main/java/com/kin/easynotes/presentation/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/navigation/NavRoutes.kt
@@ -12,6 +12,7 @@ import com.kin.easynotes.presentation.screens.settings.settings.CloudScreen
 import com.kin.easynotes.presentation.screens.settings.settings.ColorStylesScreen
 import com.kin.easynotes.presentation.screens.settings.settings.LanguageScreen
 import com.kin.easynotes.presentation.screens.settings.settings.MarkdownScreen
+import com.kin.easynotes.presentation.screens.settings.settings.PrivacyScreen
 
 sealed class NavRoutes(val route: String) {
     data object Home : NavRoutes("home")
@@ -22,6 +23,7 @@ sealed class NavRoutes(val route: String) {
     data object ColorStyles : NavRoutes("settings/color_styles")
     data object Language : NavRoutes("settings/language")
     data object Cloud : NavRoutes("settings/cloud")
+    data object Privacy : NavRoutes("settings/privacy")
     data object Markdown : NavRoutes("settings/markdown")
     data object Tools : NavRoutes("settings/tools")
     data object History : NavRoutes("settings/history")
@@ -34,6 +36,7 @@ val settingScreens = mapOf<String, @Composable (settingsViewModel: SettingsViewM
     NavRoutes.ColorStyles.route to { settings, navController -> ColorStylesScreen(navController,settings) },
     NavRoutes.Language.route to { settings, navController -> LanguageScreen(navController,settings) },
     NavRoutes.Cloud.route to { settings, navController -> CloudScreen(navController,settings) },
+    NavRoutes.Privacy.route to { settings, navController -> PrivacyScreen(navController, settings) },
     NavRoutes.Markdown.route to { settings, navController ->  MarkdownScreen(navController,settings) },
     NavRoutes.Tools.route to { settings, navController -> ToolsScreen(navController,settings) },
     NavRoutes.History.route to { settings, navController -> HistoryScreen(navController,settings) },

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.kin.easynotes.R
@@ -114,6 +116,15 @@ fun MainSettings(settingsViewModel: SettingsViewModel,navController: NavControll
                     icon = Icons.Rounded.Cloud,
                     shape = shapeManager(radius = settingsViewModel.settings.value.cornerRadius, isFirst = true),
                     action = { navController.navigate(NavRoutes.Cloud.route) })
+            }
+            item {
+                SettingCategory(
+                    title = stringResource(id = R.string.privacy),
+                    subTitle = stringResource(id = R.string.screen_protection),
+                    icon = ImageVector.vectorResource(id = R.drawable.incognito_fill),
+                    shape = shapeManager(radius = settingsViewModel.settings.value.cornerRadius),
+                    action = { navController.navigate(NavRoutes.Privacy.route) }
+                )
             }
             item {
                 SettingCategory(

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/settings/Privacy.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/settings/Privacy.kt
@@ -1,0 +1,41 @@
+package com.kin.easynotes.presentation.screens.settings.settings
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.RemoveRedEye
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.kin.easynotes.R
+import com.kin.easynotes.presentation.screens.settings.SettingsScaffold
+import com.kin.easynotes.presentation.screens.settings.model.SettingsViewModel
+import com.kin.easynotes.presentation.screens.settings.widgets.ActionType
+import com.kin.easynotes.presentation.screens.settings.widgets.SettingsBox
+
+@Composable
+fun PrivacyScreen(navController: NavController, settingsViewModel: SettingsViewModel) {
+    SettingsScaffold(
+        settingsViewModel = settingsViewModel,
+        title = stringResource(id = R.string.privacy),
+        onBackNavClicked = { navController.popBackStack() }
+    ) {
+        LazyColumn {
+            item {
+                SettingsBox(
+                    title = stringResource(id = R.string.screen_protection),
+                    icon = Icons.Filled.RemoveRedEye,
+                    radius = shapeManager(radius = settingsViewModel.settings.value.cornerRadius),
+                    actionType = ActionType.SWITCH,
+                    variable = settingsViewModel.settings.value.screenProtection,
+                    switchEnabled = {
+                        settingsViewModel.update(
+                            settingsViewModel.settings.value.copy(
+                                screenProtection = it
+                            )
+                        )
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kin/easynotes/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/theme/Theme.kt
@@ -3,6 +3,7 @@ package com.kin.easynotes.presentation.theme
 import android.app.Activity
 import android.content.Context
 import android.os.Build
+import android.view.WindowManager
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +53,11 @@ fun LeafNotesTheme(
     val activity = LocalView.current.context as Activity
     WindowCompat.getInsetsController(activity.window, activity.window.decorView).apply {
         isAppearanceLightStatusBars = !settingsModel.settings.value.darkTheme
+    }
+    if (settingsModel.settings.value.screenProtection) {
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+    } else {
+        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
     }
 
     MaterialTheme(

--- a/app/src/main/res/drawable/incognito_fill.xml
+++ b/app/src/main/res/drawable/incognito_fill.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="256" android:viewportWidth="256" android:width="24dp">
+      
+    <path android:fillColor="#FF000000" android:pathData="M256,120a8,8 0,0 1,-8 8L8,128a8,8 0,0 1,0 -16L35.92,112l47.5,-65.41a16,16 0,0 1,25.31 -0.72l12.85,14.9 0.2,0.23a7.95,7.95 0,0 0,12.44 0l0.2,-0.23 12.85,-14.9a16,16 0,0 1,25.31 0.72L220.08,112L248,112A8,8 0,0 1,256 120ZM180,144a36,36 0,0 0,-35.77 32L111.77,176a36,36 0,1 0,-1.83 16h36.12A36,36 0,1 0,180 144Z"/>
+    
+</vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -53,4 +53,6 @@
     <string name="select_radius">حدد الاستدارة</string>
     <string name="minimalistic_mode">الوضع البسيط</string>
     <string name="extreme_amoled_mode">ألوان Amoled القصوى</string>
+    <string name="privacy">الخصوصية</string>
+    <string name="screen_protection">حماية محتوى الشاشة</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,4 +53,6 @@
     <string name="select_radius">Select Radius</string>
     <string name="minimalistic_mode">Minimalistic Mode</string>
     <string name="extreme_amoled_mode">Extreme Amoled Colors</string>
+    <string name="privacy">Privacy</string>
+    <string name="screen_protection">Screen Protection</string>
 </resources>


### PR DESCRIPTION
Closes #73 

I gave up on changing the color of the app screen in the recents list to match the theme, default is always white.

I decided to add an incognito vector icon for the privacy category because I felt it's more in-line with privacy than the ones I found in the material library. The icon is from [phosphoricons](https://phosphoricons.com) and is named "detective". I don't think attribution is needed as I couldn't find anything related to crediting the creators on either the website or the github of the project, but feel free to credit them if you want to.