### PR TITLE
Pinning and sorting

### DIFF
--- a/app/src/main/java/com/kin/easynotes/core/constant/Database.kt
+++ b/app/src/main/java/com/kin/easynotes/core/constant/Database.kt
@@ -4,7 +4,7 @@ object DatabaseConst {
     /**
      * Database version
      */
-    const val NOTES_DATABASE_VERSION = 2
+    const val NOTES_DATABASE_VERSION = 3
 
     /**
      * Exported notes room database name and extension

--- a/app/src/main/java/com/kin/easynotes/data/local/database/NoteDatabaseProvider.kt
+++ b/app/src/main/java/com/kin/easynotes/data/local/database/NoteDatabaseProvider.kt
@@ -17,6 +17,7 @@ class NoteDatabaseProvider(private val application: Application) {
         if (database == null) {
             database = Room.databaseBuilder(application.applicationContext, NoteDatabase::class.java, DatabaseConst.NOTES_DATABASE_FILE_NAME)
                 .addMigrations(MIGRATION_1_2)
+                .addMigrations(MIGRATION_2_3)
                 .build()
         }
 
@@ -37,5 +38,11 @@ class NoteDatabaseProvider(private val application: Application) {
 private val MIGRATION_1_2 = object : Migration(1, 2) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE `notes-table` ADD COLUMN `created_at` INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}")
+    }
+}
+
+private val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `notes-table` ADD COLUMN `pinned` INTEGER NOT NULL DEFAULT 0")
     }
 }

--- a/app/src/main/java/com/kin/easynotes/domain/model/Note.kt
+++ b/app/src/main/java/com/kin/easynotes/domain/model/Note.kt
@@ -15,6 +15,9 @@ data class Note(
     @ColumnInfo(name = "note-description")
     val description: String,
 
+    @ColumnInfo(name = "pinned")
+    val pinned: Boolean = false,
+
     @ColumnInfo(name = "created_at")
     val createdAt: Long = System.currentTimeMillis() // Default value is the current timestamp
 )

--- a/app/src/main/java/com/kin/easynotes/domain/usecase/NoteUseCase.kt
+++ b/app/src/main/java/com/kin/easynotes/domain/usecase/NoteUseCase.kt
@@ -38,6 +38,12 @@ class NoteUseCase @Inject constructor(
         }
     }
 
+    fun pinNote(note: Note) {
+        coroutineScope.launch(NonCancellable + Dispatchers.IO) {
+            noteRepository.updateNote(note)
+        }
+    }
+
     fun deleteNoteById(id: Int) {
         coroutineScope.launch(NonCancellable + Dispatchers.IO) {
             val noteToDelete = noteRepository.getNoteById(id).first()

--- a/app/src/main/java/com/kin/easynotes/presentation/components/CustomActions.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/components/CustomActions.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Done
 import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.PushPin
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -80,5 +82,12 @@ fun TitleText(titleText: String) {
             text = titleText,
             modifier = Modifier.weight(1f)
         )
+    }
+}
+
+@Composable
+fun PinButton(isPinned: Boolean, onClick: () -> Unit) {
+    IconButton(onClick = { onClick() }) {
+        Icon(if (isPinned) Icons.Rounded.PushPin else Icons.Outlined.PushPin, contentDescription = "Pin")
     }
 }

--- a/app/src/main/java/com/kin/easynotes/presentation/components/markdown/MarkdownText.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/components/markdown/MarkdownText.kt
@@ -162,24 +162,22 @@ fun MarkdownContent(
     lines: List<String>,
     onContentChange: (String) -> Unit
 ) {
-    SelectionContainer {
-        if (isPreview) {
-            Column(
-                modifier = modifier
-            ) {
-
-                content.take(4).forEach {
-                    RenderMarkdownElement(
-                        element = it,
-                        weight = weight,
-                        fontSize = fontSize,
-                        lines = lines,
-                        onContentChange = onContentChange
-                    )
-                }
+    if (isPreview) {
+        Column(
+            modifier = modifier
+        ) {
+            content.take(4).forEach {
+                RenderMarkdownElement(
+                    element = it,
+                    weight = weight,
+                    fontSize = fontSize,
+                    lines = lines,
+                    onContentChange = onContentChange
+                )
             }
         }
-        else {
+    } else {
+        SelectionContainer {
             LazyColumn(modifier = modifier) {
                 items(content.size) { index ->
                     Spacer(modifier = Modifier.height(spacing))

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/edit/EditScreen.kt
@@ -69,6 +69,7 @@ import com.kin.easynotes.R
 import com.kin.easynotes.presentation.components.MoreButton
 import com.kin.easynotes.presentation.components.NavigationIcon
 import com.kin.easynotes.presentation.components.NotesScaffold
+import com.kin.easynotes.presentation.components.PinButton
 import com.kin.easynotes.presentation.components.SaveButton
 import com.kin.easynotes.presentation.components.markdown.MarkdownText
 import com.kin.easynotes.presentation.screens.edit.components.CustomIconButton
@@ -108,11 +109,20 @@ fun EditNoteView(
 @Composable
 fun TopBarActions(pagerState: PagerState, onClickBack: () -> Unit, viewModel: EditViewModel) {
     when (pagerState.currentPage) {
+
         0 -> {
-            SaveButton { onClickBack() }
+            Row {
+                PinButton(viewModel.isPinned.value) {
+                    viewModel.toggleNotePin(!viewModel.isPinned.value)
+                }
+                SaveButton { onClickBack() }
+            }
         }
         1 -> {
-            Box {
+            Row {
+                PinButton(viewModel.isPinned.value) {
+                    viewModel.toggleNotePin(!viewModel.isPinned.value)
+                }
                 MoreButton {
                     viewModel.toggleEditMenuVisibility(true)
                 }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/edit/model/EditModel.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/edit/model/EditModel.kt
@@ -41,12 +41,16 @@ class EditViewModel @Inject constructor(
     private val _isEditMenuVisible = mutableStateOf(false)
     val isEditMenuVisible: State<Boolean> get() = _isEditMenuVisible
 
+    private val _isPinned = mutableStateOf(false)
+    val isPinned: State<Boolean> get() = _isPinned
+
     fun saveNote(id: Int) {
         if (noteName.value.text.isNotBlank() || noteDescription.value.text.isNotBlank()) {
             noteUseCase.addNote(Note(
                 id = id,
                 name = noteName.value.text,
                 description = noteDescription.value.text,
+                pinned = isPinned.value,
                 createdAt = if (noteCreatedTime.value != 0L) noteCreatedTime.value else System.currentTimeMillis(),
             ))
         }
@@ -61,6 +65,7 @@ class EditViewModel @Inject constructor(
         updateNoteDescription(TextFieldValue(note.description, selection = TextRange(note.name.length)))
         updateNoteCreatedTime(note.createdAt)
         updateNoteId(note.id)
+        updateNotePin(note.pinned)
     }
 
     fun setupNoteData(id : Int = noteId.value) {
@@ -99,12 +104,20 @@ class EditViewModel @Inject constructor(
         _isNoteInfoVisible.value = value
     }
 
+    fun toggleNotePin(value: Boolean) {
+        _isPinned.value = value
+    }
+
     fun updateNoteName(newName: TextFieldValue) {
         _noteName.value = newName
     }
 
     private fun updateNoteCreatedTime(newTime: Long) {
         _noteCreatedTime.longValue = newTime
+    }
+
+    private fun updateNotePin(pinned: Boolean) {
+        _isPinned.value = pinned
     }
 
     fun updateNoteId(newId: Int) {

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/edit/model/EditModel.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/edit/model/EditModel.kt
@@ -43,7 +43,12 @@ class EditViewModel @Inject constructor(
 
     fun saveNote(id: Int) {
         if (noteName.value.text.isNotBlank() || noteDescription.value.text.isNotBlank()) {
-            noteUseCase.addNote(Note(id = id, name = noteName.value.text, description = noteDescription.value.text))
+            noteUseCase.addNote(Note(
+                id = id,
+                name = noteName.value.text,
+                description = noteDescription.value.text,
+                createdAt = if (noteCreatedTime.value != 0L) noteCreatedTime.value else System.currentTimeMillis(),
+            ))
         }
     }
 
@@ -59,7 +64,6 @@ class EditViewModel @Inject constructor(
     }
 
     fun setupNoteData(id : Int = noteId.value) {
-        val note: Note = Note(id = 0, name = "", description = "")
         if (id != 0) {
             viewModelScope.launch {
                 noteUseCase.getNoteById(id).collectLatest { note ->

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/home/HomeScreen.kt
@@ -29,6 +29,7 @@ import com.kin.easynotes.presentation.components.CloseButton
 import com.kin.easynotes.presentation.components.MoreButton
 import com.kin.easynotes.presentation.components.NotesButton
 import com.kin.easynotes.presentation.components.NotesScaffold
+import com.kin.easynotes.presentation.components.PinButton
 import com.kin.easynotes.presentation.components.SettingsButton
 import com.kin.easynotes.presentation.components.TitleText
 import com.kin.easynotes.presentation.screens.home.viewmodel.HomeViewModel
@@ -63,7 +64,10 @@ fun HomeView(
                     actions = {
                         val allNotes = viewModel.noteUseCase.getAllNotes.collectAsState(initial = listOf()).value
 
-                        Box {
+                        Row {
+                            PinButton(viewModel.selectedNotes.all { it.pinned }) {
+                                viewModel.pinOrUnpinNotes()
+                            }
                             MoreButton {
                                 viewModel.toggleSelectMenu(true)
                             }
@@ -78,8 +82,8 @@ fun HomeView(
                                         text = { Text(stringResource(id = R.string.select_all)) },
                                         onClick = {
                                             allNotes.forEach {
-                                                if (!viewModel.selectedNotes.contains(it.id)) {
-                                                    viewModel.selectedNotes.add(it.id)
+                                                if (!viewModel.selectedNotes.contains(it)) {
+                                                    viewModel.selectedNotes.add(it)
                                                 }
                                             }
                                         }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/home/viewmodel/HomeModel.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/home/viewmodel/HomeModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import com.kin.easynotes.domain.model.Note
 import com.kin.easynotes.domain.usecase.NoteUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -12,7 +13,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     val noteUseCase: NoteUseCase
 ) : ViewModel() {
-    var selectedNotes = mutableStateListOf<Int>()
+    var selectedNotes = mutableStateListOf<Note>()
 
     private var _isSelectMenuOpened = mutableStateOf(false)
     val isSelectMenuOpened: State<Boolean> = _isSelectMenuOpened
@@ -33,5 +34,21 @@ class HomeViewModel @Inject constructor(
 
     fun changeSearchQuery(newValue: String) {
         _searchQuery.value = newValue
+    }
+
+    fun pinOrUnpinNotes() {
+        if (selectedNotes.all { it.pinned }) {
+            selectedNotes.forEach { note ->
+                val updatedNote = note.copy(pinned = false)
+                noteUseCase.pinNote(updatedNote)
+            }
+        } else {
+            selectedNotes.forEach { note ->
+                val updatedNote = note.copy(pinned = true)
+                noteUseCase.pinNote(updatedNote)
+            }
+        }
+
+        selectedNotes.clear()
     }
 }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteFilter.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteFilter.kt
@@ -1,19 +1,23 @@
 package com.kin.easynotes.presentation.screens.home.widgets
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Notes
-import androidx.compose.material.icons.rounded.Notes
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.kin.easynotes.R
 import com.kin.easynotes.domain.model.Note
 import com.kin.easynotes.presentation.screens.settings.model.SettingsViewModel
@@ -26,7 +30,7 @@ fun NoteFilter(
     shape: RoundedCornerShape,
     notes: List<Note>,
     searchText: String? = null,
-    selectedNotes: MutableList<Int>,
+    selectedNotes: MutableList<Note>,
     viewMode: Boolean = false,
     isDeleteMode: Boolean,
     onNoteUpdate: (Note) -> Unit,
@@ -46,18 +50,43 @@ fun NoteFilter(
             placeholderText = getEmptyText(searchText)
         )
     } else {
-        NotesGrid(
-            settingsViewModel = settingsViewModel,
-            containerColor = containerColor,
-            onNoteClicked = onNoteClicked,
-            notes = filteredNotes,
-            shape = shape,
-            onNoteUpdate = onNoteUpdate,
-            selectedNotes = selectedNotes,
-            viewMode = viewMode,
-            isDeleteClicked = isDeleteMode,
-            animationFinished = onDeleteNote
-        )
+        val (pinnedNotes, otherNotes) = filteredNotes.partition { it.pinned }
+
+        Column {
+            if (pinnedNotes.isNotEmpty()) {
+                PinnedNotes(
+                    settingsViewModel = settingsViewModel,
+                    containerColor = containerColor,
+                    onNoteClicked = onNoteClicked,
+                    notes = pinnedNotes,
+                    shape = shape,
+                    onNoteUpdate = onNoteUpdate,
+                    selectedNotes = selectedNotes,
+                    viewMode = viewMode,
+                    isDeleteClicked = isDeleteMode,
+                    animationFinished = onDeleteNote
+                )
+            }
+            Column {
+                Text(
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    text = stringResource(R.string.others).uppercase(),
+                    style = TextStyle(fontSize = 11.sp, color = MaterialTheme.colorScheme.secondary)
+                )
+                NotesGrid(
+                    settingsViewModel = settingsViewModel,
+                    containerColor = containerColor,
+                    onNoteClicked = onNoteClicked,
+                    notes = otherNotes,
+                    shape = shape,
+                    onNoteUpdate = onNoteUpdate,
+                    selectedNotes = selectedNotes,
+                    viewMode = viewMode,
+                    isDeleteClicked = isDeleteMode,
+                    animationFinished = onDeleteNote
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteFilter.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteFilter.kt
@@ -3,6 +3,7 @@ package com.kin.easynotes.presentation.screens.home.widgets
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Notes
 import androidx.compose.material.icons.rounded.Notes
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
@@ -84,7 +85,7 @@ private fun getEmptyText(searchText: String?): String {
 @Composable
 private fun getEmptyIcon(searchText: String?): ImageVector {
     return when (searchText) {
-        null -> Icons.Rounded.Notes
+        null -> Icons.AutoMirrored.Rounded.Notes
         "" -> Icons.Rounded.Search
         else -> Icons.Rounded.Search
     }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteGrid.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/NoteGrid.kt
@@ -26,7 +26,7 @@ fun NotesGrid(
     shape : RoundedCornerShape,
     notes: List<Note>,
     onNoteUpdate: (Note) -> Unit,
-    selectedNotes: MutableList<Int>,
+    selectedNotes: MutableList<Note>,
     viewMode: Boolean,
     isDeleteClicked: Boolean,
     animationFinished: (Int) -> Unit
@@ -50,12 +50,12 @@ fun NotesGrid(
                         containerColor = containerColor,
                         note = note,
                         shape = shape,
-                        isBorderEnabled = selectedNotes.contains(note.id),
+                        isBorderEnabled = selectedNotes.contains(note),
                         onShortClick = { handleShortClick(selectedNotes, note, onNoteClicked) },
                         onNoteUpdate = onNoteUpdate,
                         onLongClick = { handleLongClick(selectedNotes, note) }
                     )
-                    if (isDeleteClicked && selectedNotes.contains(note.id)) {
+                    if (isDeleteClicked && selectedNotes.contains(note)) {
                         isAnimationVisible.targetState = false
                     }
                 }
@@ -76,35 +76,35 @@ private fun rememberTransitionState(): MutableTransitionState<Boolean> {
 }
 
 private fun handleShortClick(
-    selectedNotes: MutableList<Int>,
+    selectedNotes: MutableList<Note>,
     note: Note,
     onNoteClicked: (Int) -> Unit
 ) {
     if (selectedNotes.isNotEmpty()) {
-        if (selectedNotes.contains(note.id)) {
-            selectedNotes.remove(note.id)
+        if (selectedNotes.contains(note)) {
+            selectedNotes.remove(note)
         } else {
-            selectedNotes.add(note.id)
+            selectedNotes.add(note)
         }
     } else {
         onNoteClicked(note.id)
     }
 }
 
-private fun handleLongClick(selectedNotes: MutableList<Int>, note: Note) {
-    if (!selectedNotes.contains(note.id)) {
-        selectedNotes.add(note.id)
+private fun handleLongClick(selectedNotes: MutableList<Note>, note: Note) {
+    if (!selectedNotes.contains(note)) {
+        selectedNotes.add(note)
     }
 }
 
 private fun handleDeleteAnimation(
-    selectedNotes: MutableList<Int>,
+    selectedNotes: MutableList<Note>,
     note: Note,
     isAnimationVisible: MutableTransitionState<Boolean>,
     animationFinished: (Int) -> Unit
 ) {
-    if (!isAnimationVisible.targetState && !isAnimationVisible.currentState && selectedNotes.contains(note.id)) {
-        selectedNotes.remove(note.id)
+    if (!isAnimationVisible.targetState && !isAnimationVisible.currentState && selectedNotes.contains(note)) {
+        selectedNotes.remove(note)
         isAnimationVisible.targetState = true
         animationFinished(note.id)
     }

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/PinnedNotes.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/home/widgets/PinnedNotes.kt
@@ -1,0 +1,51 @@
+package com.kin.easynotes.presentation.screens.home.widgets
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kin.easynotes.R
+import com.kin.easynotes.domain.model.Note
+import com.kin.easynotes.presentation.screens.settings.model.SettingsViewModel
+
+@Composable
+fun PinnedNotes(
+    settingsViewModel: SettingsViewModel,
+    containerColor: Color,
+    onNoteClicked: (Int) -> Unit,
+    shape : RoundedCornerShape,
+    notes: List<Note>,
+    onNoteUpdate: (Note) -> Unit,
+    selectedNotes: MutableList<Note>,
+    viewMode: Boolean,
+    isDeleteClicked: Boolean,
+    animationFinished: (Int) -> Unit
+) {
+    Column {
+        Text(
+            modifier = Modifier.padding(horizontal = 12.dp),
+            text = stringResource(id = R.string.pinned).uppercase(),
+            style = TextStyle(fontSize = 11.sp, color = MaterialTheme.colorScheme.secondary)
+        )
+        NotesGrid(
+            settingsViewModel = settingsViewModel,
+            containerColor = containerColor,
+            onNoteClicked = onNoteClicked,
+            notes = notes,
+            shape = shape,
+            onNoteUpdate = onNoteUpdate,
+            selectedNotes = selectedNotes,
+            viewMode = viewMode,
+            isDeleteClicked = isDeleteClicked,
+            animationFinished = animationFinished
+        )
+    }
+}

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/SettingsScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.ArrowForwardIos
+import androidx.compose.material.icons.automirrored.rounded.ArrowForwardIos
 import androidx.compose.material.icons.rounded.Cloud
 import androidx.compose.material.icons.rounded.Coffee
 import androidx.compose.material.icons.rounded.CurrencyBitcoin
@@ -50,7 +50,7 @@ fun SettingsScaffold(
     NotesScaffold(
         topBar = {
             key(settingsViewModel.settings.value) {
-                TopBar(title, onBackNavClicked, )
+                TopBar(title, onBackNavClicked)
             }
         },
         content = {
@@ -89,7 +89,7 @@ fun MainSettings(settingsViewModel: SettingsViewModel,navController: NavControll
                     smallSetting = true,
                     title = stringResource(id = R.string.support),
                     subTitle = stringResource(id = R.string.support_description),
-                    icon = Icons.Rounded.ArrowForwardIos,
+                    icon = Icons.AutoMirrored.Rounded.ArrowForwardIos,
                     shape = shapeManager(radius = settingsViewModel.settings.value.cornerRadius, isBoth = true),
                     isLast = true,
                     composableAction = { onExit -> BottomModal(navController = navController, settingsViewModel = settingsViewModel) { onExit() }}

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/widgets/SettingsBox.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/widgets/SettingsBox.kt
@@ -6,7 +6,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -83,11 +83,12 @@ fun SettingsBox(
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = if (description.isNotBlank() || actionType == ActionType.CLIPBOARD || isBig) 12.dp else 6.dp)
+                modifier = Modifier
+                    .padding(horizontal = 20.dp, vertical = if (description.isNotBlank() || actionType == ActionType.CLIPBOARD || isBig) 12.dp else 6.dp)
+                    .fillMaxWidth()
             ) {
                 if (icon != null) RenderIcon(icon)
-                if (isCentered) Spacer(Modifier.weight(1f))
-                Column {
+                Column(Modifier.weight(1f), horizontalAlignment = if (isCentered) Alignment.CenterHorizontally else Alignment.Start) {
                     Text(
                         text = title,
                         modifier = Modifier.padding(start = 3.dp),
@@ -102,7 +103,6 @@ fun SettingsBox(
                         )
                     }
                 }
-                Spacer(modifier = Modifier.weight(1f))
                 RenderActionComponent(actionType, variable, switchEnabled, linkClicked, customText, clipboardText)
             }
         }
@@ -134,7 +134,7 @@ private fun RenderClipboardAction() {
     Icon(
         imageVector = Icons.Default.ContentCopy,
         contentDescription = null,
-        modifier = Modifier.padding(4.dp)
+        modifier = Modifier.padding(12.dp)
     )
 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -76,4 +76,6 @@
     <string name="email">البريد الإلكتروني</string>
     <string name="discord">Discord</string>
     <string name="feature">طلب الميزات</string>
+    <string name="pinned">مثبتة</string>
+    <string name="others">أخرى</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -55,4 +55,25 @@
     <string name="extreme_amoled_mode">ألوان Amoled القصوى</string>
     <string name="privacy">الخصوصية</string>
     <string name="screen_protection">حماية محتوى الشاشة</string>
+    <string name="images_supprot">دعم الصور</string>
+    <string name="unstable_feature">غير مستقر</string>
+    <string name="cryptocurrency">Cryptocurrency</string>
+    <string name="system_theme_description">تكييف مظهر التطبيق بناءً على إعدادات النظام</string>
+    <string name="dark_theme_description">التبديل بين أنظمة الألوان الداكنة و الفاتحة</string>
+    <string name="dynamic_colors_description">ضبط الألوان لتتناسب مع خلفية هاتفك</string>
+    <string name="amoled_colors_description">استخدم اللون الأسود للخلفية</string>
+    <string name="extreme_amoled_mode_description">تحسين البطارية إلى اقصى حد</string>
+    <string name="radius_description">تعديل الإستدارة حسب الطلب</string>
+    <string name="view_style_description">حدد نمط العرض</string>
+    <string name="minimalistic_mode_description">إزالة الأزرار العلوية من شاشة التحرير</string>
+    <string name="backup_description">تخزين جميع الملاحظات في ملف</string>
+    <string name="restore_description">استعادة الملاحظات من ملف</string>
+    <string name="markdown_description">تمكين Markdown في الملاحظات</string>
+    <string name="screen_protection_description">إخفاء محتوى التطبيق في شاشة التطبيقات الأخيرة و تعطيل لقطات الشاشة</string>
+    <string name="build_type">نوع الإصدار</string>
+    <string name="source_code">كود المصدر</string>
+    <string name="support_list">قائمة الداعمين</string>
+    <string name="email">البريد الإلكتروني</string>
+    <string name="discord">Discord</string>
+    <string name="feature">طلب الميزات</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,6 @@
     <string name="email">Email</string>
     <string name="discord">Discord</string>
     <string name="feature">Feature Request</string>
+    <string name="pinned">Pinned</string>
+    <string name="others">Others</string>
 </resources>


### PR DESCRIPTION
This PR adds support for pinning notes and sorting them by last updated date. Draft because only pinning is done for now.

- [x] Pinning
- [ ] Sorting
  - By default the notes will be sorted by a new database column `updatedAt` which holds the last time a note was modified or updated (excluding pinning?)

I've also fixed a few minor issues I ran into, such as:-
- `Created At` date of a note would be updated if it was opened and closed even if the title or description was not updated. With the new fix and sorting feature the `Created At` column is never updated, while the `updatedAt` column is updated whenever the note is edited.
- When long pressing a note from the home screen the note's title or description might be selected which is an annoying experience for the user. Selecting text from the edit screen still works as expected.
- Some icons did not flip along the Y axis for RTL languages.
- If the description of a `SettingsBox` is long enough it will overflow into the action component area such as the `Switch`.
- The icon for the support email `SettingsBox` was not aligned with the icons of the other `SettingsBox`s