### PR TITLE
feat: setting to change the app language

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,11 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        // https://developer.android.com/guide/topics/resources/app-languages#gradle-config
+        resourceConfigurations.plus(
+            listOf("en", "ar", "de", "es", "fa", "fil", "fr", "hi", "it", "ja", "ru", "sk", "tr")
+        )
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,12 +7,13 @@
         android:grantUriPermissions="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="false"
+        android:localeConfig="@xml/locales_config"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.EasySplash"
-        tools:targetApi="31">
+        tools:targetApi="34">
         <receiver android:name=".widget.AddNoteReceiver"
             android:exported="true">
             <intent-filter>
@@ -52,6 +53,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false"
+        >
+            <meta-data android:name="autoStoreLocales" android:value="true" />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kin/easynotes/presentation/MainActivity.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.kin.easynotes.presentation
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -17,7 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var settingsRepositoryImpl: SettingsRepositoryImpl
 

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/model/SettingsModel.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/model/SettingsModel.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kin.easynotes.BuildConfig
@@ -17,6 +18,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -65,6 +69,40 @@ class SettingsViewModel @Inject constructor(
             handleBackupResult(result, context)
             databaseUpdate.value = true
         }
+    }
+
+    // Taken from: https://stackoverflow.com/questions/74114067/get-list-of-locales-from-locale-config-in-android-13
+    private fun getLocaleListFromXml(context: Context): LocaleListCompat {
+        val tagsList = mutableListOf<CharSequence>()
+        try {
+            val xpp: XmlPullParser = context.resources.getXml(R.xml.locales_config)
+            while (xpp.eventType != XmlPullParser.END_DOCUMENT) {
+                if (xpp.eventType == XmlPullParser.START_TAG) {
+                    if (xpp.name == "locale") {
+                        tagsList.add(xpp.getAttributeValue(0))
+                    }
+                }
+                xpp.next()
+            }
+        } catch (e: XmlPullParserException) {
+            e.printStackTrace()
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+
+        return LocaleListCompat.forLanguageTags(tagsList.joinToString(","))
+    }
+
+    fun getSupportedLanguages(context: Context): Map<String, String> {
+        val localeList = getLocaleListFromXml(context)
+        val map = mutableMapOf<String, String>()
+
+        for (a in 0 until localeList.size()) {
+            localeList[a].let {
+                it?.let { it1 -> map.put(it1.getDisplayName(it), it.toLanguageTag()) }
+            }
+        }
+        return map
     }
 
     private fun handleBackupResult(result: BackupResult, context: Context) {

--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/settings/Colors.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/settings/Colors.kt
@@ -1,7 +1,11 @@
 package com.kin.easynotes.presentation.screens.settings.settings
 
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,9 +22,11 @@ import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.HdrAuto
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.RoundedCorner
+import androidx.compose.material.icons.rounded.Translate
 import androidx.compose.material.icons.rounded.ViewAgenda
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
@@ -29,13 +35,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.core.os.LocaleListCompat
 import androidx.navigation.NavController
 import com.kin.easynotes.R
 import com.kin.easynotes.presentation.screens.settings.SettingsScaffold
@@ -126,6 +135,21 @@ fun ColorStylesScreen(navController: NavController, settingsViewModel: SettingsV
             }
             item {
                 SettingsBox(
+                    title = stringResource(id = R.string.language),
+                    description = stringResource(id = R.string.language_description),
+                    icon = Icons.Rounded.Translate,
+                    radius = shapeManager(radius = settingsViewModel.settings.value.cornerRadius, isBoth = true),
+                    actionType = ActionType.CUSTOM,
+                    customAction = {
+                        onExit -> OnLanguageClicked(settingsViewModel) {
+                            onExit()
+                        }
+                    }
+                )
+                Spacer(modifier = Modifier.height(18.dp))
+            }
+            item {
+                SettingsBox(
                     title = stringResource(id = R.string.radius),
                     description = stringResource(id = R.string.radius_description),
                     icon = Icons.Rounded.RoundedCorner,
@@ -171,6 +195,67 @@ fun ColorStylesScreen(navController: NavController, settingsViewModel: SettingsV
                     variable = settingsViewModel.settings.value.minimalisticMode,
                     switchEnabled = { settingsViewModel.update(settingsViewModel.settings.value.copy(minimalisticMode = it))}
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnLanguageClicked(settingsViewModel: SettingsViewModel, onExit: () -> Unit) {
+    val context = LocalContext.current
+    val languages = settingsViewModel.getSupportedLanguages(context)
+
+    @Composable
+    fun Language(displayName: String, selected: Boolean, onClick: () -> Unit) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .clickable { onClick() }) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp, horizontal = 24.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(displayName)
+                RadioButton(
+                    selected = selected,
+                    onClick = null,
+                )
+            }
+        }
+    }
+
+    Dialog(onDismissRequest = onExit) {
+        Card(shape = shapeManager(radius = settingsViewModel.settings.value.cornerRadius)) {
+            Text(
+                text = stringResource(R.string.language),
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp, bottom = 16.dp)
+            )
+            LazyColumn {
+                item {
+                    Language(
+                        displayName = stringResource(R.string.system_language),
+                        selected = AppCompatDelegate.getApplicationLocales().isEmpty
+                    ) {
+                        AppCompatDelegate.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+                    }
+                }
+                for ((name, tag) in languages) {
+                    item {
+                        Language(
+                            displayName = name,
+                            selected = AppCompatDelegate.getApplicationLocales()[0]?.language == tag
+                        ) {
+                            AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag))
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -68,7 +68,7 @@
     <string name="minimalistic_mode_description">إزالة الأزرار العلوية من شاشة التحرير</string>
     <string name="backup_description">تخزين جميع الملاحظات في ملف</string>
     <string name="restore_description">استعادة الملاحظات من ملف</string>
-    <string name="markdown_description">تمكين Markdown في الملاحظات</string>
+    <string name="markdown_description">تفعيل Markdown في الملاحظات</string>
     <string name="screen_protection_description">إخفاء محتوى التطبيق في شاشة التطبيقات الأخيرة و تعطيل لقطات الشاشة</string>
     <string name="build_type">نوع الإصدار</string>
     <string name="source_code">كود المصدر</string>
@@ -87,4 +87,11 @@
     <string name="sort_ascending">ترتيب تصاعدي</string>
     <string name="sort_descending">ترتيب تنازلي</string>
     <string name="sort_description">ترتيب الملاحظات حسب وقت إنشائها</string>
+    <string name="select_note">إختر ملاحظة</string>
+    <string name="unsuported_image_size">حجم الصورة غير مدعوم (15 ميجابايت كحد أقصى)</string>
+    <string name="vault">الخزنة</string>
+    <string name="vault_description">تفعيل خزنة الملاحظات المشفرة</string>
+    <string name="password_continue">اكمل</string>
+    <string name="language_description">تغيير لغة التطبيق</string>
+    <string name="system_language">اتبع لغة النظام</string>
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.EasyNotes" parent="android:Theme.Material.NoActionBar" />
+    <style name="Theme.EasyNotes" parent="Theme.AppCompat.DayNight.NoActionBar" />
 
     <style name="Theme.EasySplash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/backgroundDark</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,4 +92,6 @@
     <string name="vault">Vault</string>
     <string name="vault_description">Enable encrypted notes vault</string>
     <string name="password_continue">continue</string>
+    <string name="language_description">Change the app language</string>
+    <string name="system_language">System Language</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.EasyNotes" parent="android:Theme.Material.NoActionBar" />
+    <style name="Theme.EasyNotes" parent="Theme.AppCompat.DayNight.NoActionBar" />
 
     <style name="Theme.EasySplash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/backgroundDark</item>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="ar" />
+    <locale android:name="de" />
+    <locale android:name="es" />
+    <locale android:name="fa" />
+    <locale android:name="fil" />
+    <locale android:name="fr" />
+    <locale android:name="hi" />
+    <locale android:name="it" />
+    <locale android:name="ja" />
+    <locale android:name="ru" />
+    <locale android:name="sk" />
+    <locale android:name="tr" />
+</locale-config>
+


### PR DESCRIPTION
This also supports Android 13's per-app language preferences (https://developer.android.com/guide/topics/resources/app-languages)

I had to change the app theme and MainActivity to be AppCompat because `LocaleListCompat` doesn't seem to work with a material theme and activity. Reference: https://stackoverflow.com/questions/74411797/android-jetpack-compose-language-switching-via-appcompatdelegate-is-not-working

