### PR TITLE
Fix backup filename

### DIFF
--- a/app/src/main/java/com/kin/easynotes/presentation/screens/settings/settings/Backup.kt
+++ b/app/src/main/java/com/kin/easynotes/presentation/screens/settings/settings/Backup.kt
@@ -183,7 +183,7 @@ fun CloudScreen(navController: NavController, settingsViewModel: SettingsViewMod
 
 fun currentDateTime(): String {
     val currentDateTime = LocalDateTime.now()
-    val formatter = DateTimeFormatter.ofPattern("MM-dd-HH-mm-ms")
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
     val formattedDateTime = currentDateTime.format(formatter)
 
     return formattedDateTime


### PR DESCRIPTION
Default backup file name does not include a year, which is confusing.

This small change makes backups lexicographically sortable.